### PR TITLE
Include avahi-daemon package in apt-get installation suggestion

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ Watch the [demo video here](https://youtu.be/QAbOHhjo05U).
 ##### Install the OpenHAB HomeKit Bridge:
 * On non OS X systems install the avahi library:
 
-  `sudo apt-get install libavahi-compat-libdnssd-dev`
+  `sudo apt-get install avahi-daemon libavahi-compat-libdnssd-dev`
 * Install the node module dependencies:
 
   `npm install`


### PR DESCRIPTION
On a fresh install of Ubuntu server, installing libavahi-compat-libdnssd-dev alone does not install avahi-daemon, so an error occurs when attempting to start OpenHAB-HomeKit-Bridge.

The README should probably include the suggestion to install avahi-daemon along with libavahi-compat-libdnssd-dev.
