### PR TITLE
Use hap-nodejs v0.2.3 to fix disconnections

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-stage-2": "^6.1.2",
     "crypto": "0.0.3",
     "debug": "^2.2.0",
-    "hap-nodejs": "0.1.7",
+    "hap-nodejs": "0.2.3",
     "request": "^2.55.0",
     "stdio": "^0.2.7",
     "ws": "^0.8.0"


### PR DESCRIPTION
With version 0.1.7 of hap-nodejs, the service starts correctly on linux (and functions as expected), but after a few minutes, the device loses the connection to the bridge and is unable to do anything with the bridged accessories without restarting OpenHAB-HomeKit-Bridge.

The same behavior is noted in this issue: https://github.com/KhaosT/HAP-NodeJS/issues/213

By upgrading to hap-nodejs version 0.2.3, the issue is resolved for me.
